### PR TITLE
fix: add a default sheet name to avoid corruption

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub fn csv2xlsx<I: Read>(
 
     let mut workbook = Workbook::create_in_memory();
 
-    let mut sheet = workbook.create_sheet("");
+    let mut sheet = workbook.create_sheet("default");
 
     let mut records = Vec::new();
     for result in reader.records() {


### PR DESCRIPTION
When there is no name on the sheet Excel tag the file as corrupt

https://stackoverflow.com/questions/48643025/sheetjs-repaired-records-worksheet-properties-from-xl-workbook-xml-part-work